### PR TITLE
Email: Optionally enable TLS via CLOUDRON_MAIL_TLS

### DIFF
--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -28,6 +28,7 @@ No email configuration found. Set the following environment variables:
     CLOUDRON_MAIL_SMTP_USERNAME
     CLOUDRON_MAIL_SMTP_PASSWORD
     CLOUDRON_MAIL_FROM
+    CLOUDRON_MAIL_TLS  (optional)
     `);
 }
 
@@ -244,6 +245,7 @@ function sendNotificationEmail(release, callback) {
             var transport = nodemailer.createTransport(smtpTransport({
                 host: process.env.CLOUDRON_MAIL_SMTP_SERVER,
                 port: process.env.CLOUDRON_MAIL_SMTP_PORT,
+                secure: !!process.env.CLOUDRON_MAIL_TLS,
                 auth: {
                     user: process.env.CLOUDRON_MAIL_SMTP_USERNAME,
                     pass: process.env.CLOUDRON_MAIL_SMTP_PASSWORD

--- a/backend/tasks.js
+++ b/backend/tasks.js
@@ -28,7 +28,7 @@ No email configuration found. Set the following environment variables:
     CLOUDRON_MAIL_SMTP_USERNAME
     CLOUDRON_MAIL_SMTP_PASSWORD
     CLOUDRON_MAIL_FROM
-    CLOUDRON_MAIL_TLS  (optional)
+    MAIL_TLS  (optional)
     `);
 }
 
@@ -245,7 +245,7 @@ function sendNotificationEmail(release, callback) {
             var transport = nodemailer.createTransport(smtpTransport({
                 host: process.env.CLOUDRON_MAIL_SMTP_SERVER,
                 port: process.env.CLOUDRON_MAIL_SMTP_PORT,
-                secure: !!process.env.CLOUDRON_MAIL_TLS,
+                secure: !!process.env.MAIL_TLS,
                 auth: {
                     user: process.env.CLOUDRON_MAIL_SMTP_USERNAME,
                     pass: process.env.CLOUDRON_MAIL_SMTP_PASSWORD


### PR DESCRIPTION
Some configurations run their SMTP server with TLS only. If clients don't connect initially using TLS, the server will reject them, as that's out of TLS's spec. Adding this environment variable and setting it to a truthy string value will tell nodemailer to utilize TLS for initial connection.